### PR TITLE
Jet matcher refs

### DIFF
--- a/src/jet_matcher.erl
+++ b/src/jet_matcher.erl
@@ -6,8 +6,6 @@
 -compile(export_all).
 -endif.
 
--include_lib("eunit/include/eunit.hrl").
-
 match(#{<<"and">> := Ands}, Json) when is_list(Ands) ->
     lists:all(fun (And) -> match(And, Json) end, Ands);
 match(#{<<"or">> := Ors}, Json) when is_list(Ors) ->

--- a/test/fixtures/jet_matcher.json
+++ b/test/fixtures/jet_matcher.json
@@ -9,7 +9,8 @@
       [
         { "name": "John", "age": 30, "balance": 15000 },
         { "name": "Mary", "age": 50, "balance": 20000.50 }
-      ]
+      ],
+      "details2": { "name": "Zeus", "age": 30, "balance": 100.05 }
     },
     "patterns":
     [
@@ -790,6 +791,26 @@
         "description": "type(any,object) - no match",
         "pattern": { "/details/balance": { "type": "object" } },
         "result": false
+      },
+      {
+        "description": "type(any,object) - no match",
+        "pattern": { "/details/balance": { "type": "object" } },
+        "result": false
+      },
+      {
+        "description": "=(string,string) - match reference ($ref)",
+        "pattern": { "/details/name": { "=": { "$ref": "/details2/name"} } },
+        "result": true
+      },
+      {
+        "description": "<(int,int) - match reference ($ref)",
+        "pattern": { "/details/age": { "<": { "$ref": "/details2/age"} } },
+        "result": true
+      },
+      {
+        "description": ">(int,int) - match reference ($ref)",
+        "pattern": { "/details2/age": { ">": { "$ref": "/details/age"} } },
+        "result": true
       },
       {
         "description": "and/or/not pattern",


### PR DESCRIPTION
Added ability to compare values in match object to other values in the same object using $refs, instead of just being able to compare to literal values, via the following syntax

"/path/to/prop": { "=": { "$ref": "/path/to/another/prop" } }