### PR TITLE
Merge delete

### DIFF
--- a/src/jet_pointer.erl
+++ b/src/jet_pointer.erl
@@ -1,6 +1,6 @@
 -module(jet_pointer).
 
--export([get/2, get/3, put/3]).
+-export([get/2, put/3, remove/2]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -55,7 +55,23 @@ put(PathList, _Value, Json) when is_list(PathList), is_list(Json), length(PathLi
 put([], Value, _Json) ->
     Value.
 
-%% --
+remove(PathString, Map) when is_binary(PathString) ->
+    remove(string:lexemes(PathString, "/"), Map);
+remove([Key | []], Json) when is_map(Json) ->
+    case maps:is_key(Key, Json) of
+        true ->
+            maps:remove(Key,Json);
+        false ->
+            Json
+    end;
+remove([Key | Path], Json) when is_map(Json) ->
+    case maps:is_key(Key, Json) of
+        true ->
+            NestedValue = remove(Path, maps:get(Key, Json)),
+            maps:update(Key, NestedValue, Json);
+        false ->
+            Json
+    end.
 
 parse(Path) when is_list(Path) ->
     parse(list_to_binary(Path), []);

--- a/src/jet_pointer.erl
+++ b/src/jet_pointer.erl
@@ -1,6 +1,6 @@
 -module(jet_pointer).
 
--export([get/2, put/3, remove/2]).
+-export([get/2, get/3, put/3, remove/2]).
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/test/fixtures/jet_merger.json
+++ b/test/fixtures/jet_merger.json
@@ -120,5 +120,18 @@
         }
       }
     ]
+  },
+  {
+    "source-object":
+      {"a": 1, "b": 2},
+    "merges":
+    [
+      {
+        "description": "delete property",
+        "dest-object": {"b":1, "c": 3, "d": {"e": {"f": 1, "g": 1}, "h": 2}},
+        "merge-spec":  {"/": "merge", "/d/e": "delete", "/i": "delete"},
+        "result": {"a":1, "b":2, "c": 3, "d": {"h": 2}}
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added "delete" merge instruction to jet_merger along with jet_pointer:remove function to facilitate it. Allowing e.g.

Merge spec: {"/": "merge", "/d/e": "delete", "/i": "delete"}